### PR TITLE
A few changes to compile with DMD 2.67 and current phobos.

### DIFF
--- a/source/dyaml/composer.d
+++ b/source/dyaml/composer.d
@@ -55,13 +55,13 @@ final class Composer
         ///We need one appender for each nesting level that involves
         ///a pair array, as the inner levels are processed as a
         ///part of the outer levels. Used as a stack.
-        Appender!(Node.Pair[], Node.Pair)[] pairAppenders_;
+        Appender!(Node.Pair[])[] pairAppenders_;
         ///Used to reduce allocations when creating node arrays.
         ///
         ///We need one appender for each nesting level that involves
         ///a node array, as the inner levels are processed as a
         ///part of the outer levels. Used as a stack.
-        Appender!(Node[], Node)[] nodeAppenders_;
+        Appender!(Node[])[] nodeAppenders_;
 
     public:
         /**

--- a/source/dyaml/constructor.d
+++ b/source/dyaml/constructor.d
@@ -347,7 +347,7 @@ final class Constructor
          *          ctor = Constructor function.
          */
         auto addConstructor(T)(const Tag tag, T function(ref Node) ctor)
-            @safe pure nothrow
+            @safe nothrow
         {
             assert((tag in fromScalar_) is null &&
                    (tag in fromSequence_) is null &&
@@ -859,7 +859,7 @@ struct MyStruct
 {
     int x, y, z;
 
-    const int opCmp(ref const MyStruct s) const pure @safe nothrow
+    const int opCmp(ref const MyStruct s) pure @safe nothrow
     {
         if(x != s.x){return x - s.x;}
         if(y != s.y){return y - s.y;}

--- a/source/dyaml/fastcharsearch.d
+++ b/source/dyaml/fastcharsearch.d
@@ -70,7 +70,7 @@ string searchCode(dstring chars, uint tableSize)() @safe pure //nothrow
     {
         code ~= 
         q{
-            static immutable ubyte table_[%s] = [
+            static immutable ubyte[%s] table_ = [
             %s];
         }.format(tableSize, table[].map!(c => c ? q{true} : q{false}).join(q{, }));
     }

--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -1804,7 +1804,7 @@ package:
 //
 // Params:  pairs   = Appender managing the array of pairs to merge into.
 //          toMerge = Pair to merge.
-void merge(ref Appender!(Node.Pair[], Node.Pair) pairs, ref Node.Pair toMerge) @trusted
+void merge(ref Appender!(Node.Pair[]) pairs, ref Node.Pair toMerge) @trusted
 {
     foreach(ref pair; pairs.data)
     {
@@ -1820,7 +1820,7 @@ void merge(ref Appender!(Node.Pair[], Node.Pair) pairs, ref Node.Pair toMerge) @
 //
 // Params:  pairs   = Appender managing the array of pairs to merge into.
 //          toMerge = Pairs to merge.
-void merge(ref Appender!(Node.Pair[], Node.Pair) pairs, Node.Pair[] toMerge) @trusted
+void merge(ref Appender!(Node.Pair[]) pairs, Node.Pair[] toMerge) @trusted
 {
     bool eq(ref Node.Pair a, ref Node.Pair b){return a.key == b.key;}
 

--- a/source/dyaml/nogcutil.d
+++ b/source/dyaml/nogcutil.d
@@ -12,6 +12,7 @@ module dyaml.nogcutil;
 
 import std.traits;
 import std.typecons;
+import std.typetuple : TypeTuple;
 import std.range;
 
 

--- a/source/dyaml/representer.d
+++ b/source/dyaml/representer.d
@@ -602,7 +602,7 @@ struct MyStruct
 {
     int x, y, z;
 
-    const int opCmp(ref const MyStruct s) const pure @safe nothrow
+    const int opCmp(ref const MyStruct s) pure @safe nothrow
     {
         if(x != s.x){return x - s.x;}
         if(y != s.y){return y - s.y;}


### PR DESCRIPTION
It looks like phobos' 452eab0e03f78e786516bf1c357dd0d863b7b729 changed the signature for Appender. More invasively, Constructor's `addConstructor(T)(const Tag, T function(ref Node))` wouldn't compile if pure. (Tests pass with that function impure, for whatever that's worth.) There are a few redundant const attributes that 2.67 is fussy about.