### PR TITLE
fix emitting of unicode characters >0xFFFF

### DIFF
--- a/source/dyaml/emitter.d
+++ b/source/dyaml/emitter.d
@@ -1401,7 +1401,7 @@ struct ScalarWriter
                         {
                             //Write an escaped Unicode character.
                             const format = c <= 255   ? "\\x%02X":
-                                           c <= 65535 ? "\\u%04X": "\\u%08X";
+                                           c <= 65535 ? "\\u%04X": "\\U%08X";
                             formattedWrite(appender, format, cast(uint)c);
                         }
 


### PR DESCRIPTION
Escaped unicode characters above 0xFFFF are currently being emitted as \uXXXXXXXX when they should be \UXXXXXXXX. Seems there was just a simple typo to fix.