### PR TITLE
avoid use of a static constructor in parser

### DIFF
--- a/source/dyaml/parser.d
+++ b/source/dyaml/parser.d
@@ -114,11 +114,8 @@ final class Parser
 {
     private:
         ///Default tag handle shortcuts and replacements.
-        static TagDirective[] defaultTagDirectives_;
-        static this()
-        {
-            defaultTagDirectives_ = [TagDirective("!", "!"), TagDirective("!!", "tag:yaml.org,2002:")];
-        }
+        static TagDirective[] defaultTagDirectives_ = 
+            [TagDirective("!", "!"), TagDirective("!!", "tag:yaml.org,2002:")];
 
         ///Scanner providing YAML tokens.
         Scanner scanner_;


### PR DESCRIPTION
This makes usage in module constructors more reliable and improves consistency with the emitter.

Prior to this fix, D-YAML was unusable for parsing yaml files without significant workarounds when using vibe.d.