### PR TITLE
fix for lookup change in 2.071.0

### DIFF
--- a/source/dyaml/emitter.d
+++ b/source/dyaml/emitter.d
@@ -67,6 +67,9 @@ align(4) struct ScalarAnalysis
 ///Quickly determines if a character is a newline.
 private mixin FastCharSearch!"\n\u0085\u2028\u2029"d newlineSearch_;
 
+// override the canFind added by the FastCharSearch mixins
+private alias canFind = std.algorithm.canFind;
+
 //Emits YAML events into a file/stream.
 struct Emitter 
 {


### PR DESCRIPTION
- local symbols are preferred over imported symbols making the mixed in
  canFind hide std.algorithm.canFind